### PR TITLE
Create versioned wheels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 build-release:
-	python3 setup.py bdist_wheel --dist-dir wheels
+	python3 setup.py bdist_wheel

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+build-release:
+	python3 setup.py bdist_wheel --dist-dir wheels

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ This module exposes the necessary API to create a worker which starts polling me
 We can install the library through github by writing the dependency in `requirements.txt` as:
 
 ```
-https://raw.githubusercontent.com/epidemicsound/aws-sqs-worker/master/wheels/aws_sqs_worker-0.0.1-py3-none-any.whl
+https://github.com/epidemicsound/aws-sqs-worker/releases/download/v0.0.1/aws_sqs_worker-0.0.1-py3-none-any.whl
 ```
 
-Replace 0.0.1 with the desired version!
+Replace 0.0.1 with the desired version, on both places in the url!
 
-If using pipenv, you can also run `pipenv install https://raw.githubusercontent.com/epidemicsound/aws-sqs-worker/master/wheels/aws_sqs_worker-0.0.1-py3-none-any.whl`.
+If using pipenv, you can also run `pipenv install https://github.com/epidemicsound/aws-sqs-worker/releases/download/v0.0.1/aws_sqs_worker-0.0.1-py3-none-any.whl`.
 
 ## Steps necessary to create a worker for the process:
 
@@ -57,8 +57,10 @@ Use semantic versioning for this library. When bumping the version, please updat
 * setup.py
 * this readme
 
-Make sure you generate a new wheel (after bumping the version) by running `make build-release`.
+Merge into master.
 
-Make sure that the new wheel is named `aws_sqs_worker-<version>-py3-none-any.whl` and is in the `wheels` folder..
+Generate a new wheel (after bumping the version and being on the new master) by running `make build-release`.
 
-Include the wheel in git.
+Make sure that there is a new wheel named `aws_sqs_worker-<version>-py3-none-any.whl` and is in the `dist` folder.
+
+Create a github release and upload the wheel file to the release.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@ This module exposes the necessary API to create a worker which starts polling me
 We can install the library through github by writing the dependency in `requirements.txt` as:
 
 ```
-git+https://github.com/epidemicsound/aws-sqs-worker.git#egg=aws-sqs-worker
+https://raw.githubusercontent.com/epidemicsound/aws-sqs-worker/master/wheels/aws_sqs_worker-0.0.1-py3-none-any.whl
 ```
+
+Replace 0.0.1 with the desired version!
+
+If using pipenv, you can also run `pipenv install https://raw.githubusercontent.com/epidemicsound/aws-sqs-worker/master/wheels/aws_sqs_worker-0.0.1-py3-none-any.whl`.
 
 ## Steps necessary to create a worker for the process:
 
@@ -45,3 +49,16 @@ queue_worker.start()
 ```
 
 This will then start the queue polling mechanism by the `queue_worker`. As soon as message appears on the `queue_name`, it invokes the `handle_payload` function of `myworker` instance.
+
+## Release
+
+Use semantic versioning for this library. When bumping the version, please update the version in:
+
+* setup.py
+* this readme
+
+Make sure you generate a new wheel (after bumping the version) by running `make build-release`.
+
+Make sure that the new wheel is named `aws_sqs_worker-<version>-py3-none-any.whl` and is in the `wheels` folder..
+
+Include the wheel in git.


### PR DESCRIPTION
Editable and unversioned dependencies are scary. Pushing dependencies to
a repository is nice but not always easy.

This enables us to push new releases and make sure that old versions (installed
as wheels, not as git editables) aren't affected until they decide to update.