### PR TITLE
Liveness callback and raise on missing environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ This module exposes the necessary API to create a worker which starts polling me
 We can install the library through github by writing the dependency in `requirements.txt` as:
 
 ```
-https://github.com/epidemicsound/aws-sqs-worker/releases/download/v0.0.1/aws_sqs_worker-0.0.1-py3-none-any.whl
+https://github.com/epidemicsound/aws-sqs-worker/releases/download/v0.0.2/aws_sqs_worker-0.0.2-py3-none-any.whl
 ```
 
-Replace 0.0.1 with the desired version, on both places in the url!
+Replace 0.0.2 with the desired version, on both places in the url!
 
-If using pipenv, you can also run `pipenv install https://github.com/epidemicsound/aws-sqs-worker/releases/download/v0.0.1/aws_sqs_worker-0.0.1-py3-none-any.whl`.
+If using pipenv, you can also run `pipenv install https://github.com/epidemicsound/aws-sqs-worker/releases/download/v0.0.2/aws_sqs_worker-0.0.2-py3-none-any.whl`.
 
 ## Steps necessary to create a worker for the process:
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name='aws-sqs-worker',
-    version='0.0.1',
+    version='0.0.2',
     description='AWS SQS Worker Module',
     license='MIT',
     long_description=long_description,

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -9,7 +9,7 @@ from . import (
 
 
 class QueueServiceWorker:
-    def __init__(self, queue_name, handler, logger, liveness_callback):
+    def __init__(self, queue_name, handler, logger, liveness_callback=None):
         self.queue_name = queue_name
         self.handler = handler
         self.logger = logger

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -9,10 +9,11 @@ from . import (
 
 
 class QueueServiceWorker:
-    def __init__(self, queue_name, handler, logger):
+    def __init__(self, queue_name, handler, logger, liveness_callback):
         self.queue_name = queue_name
         self.handler = handler
         self.logger = logger
+        self.liveness_callback = liveness_callback
 
         if settings.QUEUE_SERVICE_HOST is None:
             raise Exception("aws-sqs-worker is missing a 'QUEUE_SERVICE_HOST' environment variable")
@@ -78,6 +79,9 @@ class QueueServiceWorker:
                     time.sleep(settings.NO_MESSAGE_SLEEP_INTERVAL)
                 else:
                     raise Exception('Unhandled error {}', message_type)
+
+            if self.liveness_callback is not None:
+                self.liveness_callback()
 
         self.logger.info('Work loop exited')
 

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -13,6 +13,10 @@ class QueueServiceWorker:
         self.queue_name = queue_name
         self.handler = handler
         self.logger = logger
+
+        if settings.QUEUE_SERVICE_HOST is None:
+            raise Exception("aws-sqs-worker is missing a 'QUEUE_SERVICE_HOST' environment variable")
+
         self.client = request_client.Client(settings.QUEUE_SERVICE_HOST)
 
         self.run = True


### PR DESCRIPTION
This PR includes 2 refinements:
- Added support for a liveness_callback, which triggers every time the worker completes a loop of check ing of there are any available messages in the queue.
- An exception being raised if there is no configured `QUEUE_SERVICE_HOST` environment variable.